### PR TITLE
Enforce password history

### DIFF
--- a/administrator/language/en-GB/en-GB.plg_user_passwordpolicy.sys.ini
+++ b/administrator/language/en-GB/en-GB.plg_user_passwordpolicy.sys.ini
@@ -6,6 +6,8 @@
 PLG_USER_PASSWORDPOLICY="Password Policy for User"
 PLG_USER_PASSWORDPOLICY_XML_DESCRIPTION="Password policies."
 
+PLG_USER_PASSWORDPOLICY_ENFORCEPASSWORDHISTORY_DESC="The Enforce password history policy setting determines the number of unique new passwords that must be associated with a user account before an old password can be reused."
+PLG_USER_PASSWORDPOLICY_ENFORCEPASSWORDHISTORY_LABEL="Enforce password history"
 PLG_USER_PASSWORDPOLICY_MAXIMUMPASSWORDAGE_DESC="The Maximum password age policy setting determines the period of time (in days) that a password can be used before the system requires the user to change it. You can set passwords to expire after a number of days between 1 and 180, or you can specify that passwords never expire by setting the number of days to 0. You can set this option both globally and for each individual user. The plug-in is designed to follow the most restrictive policy."
 PLG_USER_PASSWORDPOLICY_MAXIMUMPASSWORDAGE_LABEL="Maximum password age"
 PLG_USER_PASSWORDPOLICY_MINIMUMPASSWORDAGE_DESC="The Minimum password age policy setting determines the period of time (in days) that a password must be used before the user can change it. The minimum password age must be less than the Maximum password age."

--- a/administrator/language/it-IT/it-IT.plg_user_passwordpolicy.sys.ini
+++ b/administrator/language/it-IT/it-IT.plg_user_passwordpolicy.sys.ini
@@ -6,6 +6,8 @@
 PLG_USER_PASSWORDPOLICY="Password Policy for User"
 PLG_USER_PASSWORDPOLICY_XML_DESCRIPTION="Password policies."
 
+PLG_USER_PASSWORDPOLICY_ENFORCEPASSWORDHISTORY_DESC="L'impostazione Imponi cronologia password definisce il numero di nuove password uniche che devono essere associate a un account utente prima che una vecchia password possa essere riutilizzata."
+PLG_USER_PASSWORDPOLICY_ENFORCEPASSWORDHISTORY_LABEL="Imponi cronologia password"
 PLG_USER_PASSWORDPOLICY_MAXIMUMPASSWORDAGE_DESC="L'impostazione validità massima password determina il periodo di tempo (in giorni) che una password può essere utilizzata prima che il sistema richiede all'utente di modificarla. È possibile impostare che le password scadono dopo un numero di giorni compresi tra 1 e 180 oppure è possibile specificare che le password non scadono mai impostando il numero di giorni a 0. La politica può essere impostata a livello globale o a livello di singolo utente. Il plugin prende la politica più restrittiva."
 PLG_USER_PASSWORDPOLICY_MAXIMUMPASSWORDAGE_LABEL="Validità massima password"
 PLG_USER_PASSWORDPOLICY_MINIMUMPASSWORDAGE_DESC="L'impostazione validità minima password determina il periodo di tempo (in giorni) che una password deve essere utilizzata prima che l'utente possa richiederne la modifica. La validità minima password deve essere minore della validità massima password."

--- a/plugins/user/passwordpolicy/passwordpolicy.xml
+++ b/plugins/user/passwordpolicy/passwordpolicy.xml
@@ -32,6 +32,15 @@
 			validate="passwordage"
 			field="maximumPasswordAge"
 		  />
+          <field
+            name="enforcePasswordHistory"
+            type="number"
+            label="PLG_USER_PASSWORDPOLICY_ENFORCEPASSWORDHISTORY_LABEL"
+            description="PLG_USER_PASSWORDPOLICY_ENFORCEPASSWORDHISTORY_DESC"
+            filter="integer"
+            default="0"
+            first="0" last="24" step="1"
+          />
         <field name="passwordExpirationReminder" type="radio" default="1" class="btn-group btn-group-yesno" description="PLG_USER_PASSWORDPOLICY_PASSWORDEXPIRATIONREMINDER_DESC" label="PLG_USER_PASSWORDPOLICY_PASSWORDEXPIRATIONREMINDER_LABEL">
           <option value="1">JYES</option>
           <option value="0">JNO</option>


### PR DESCRIPTION
### Summary of Changes
Aggiunta opzione Imponi cronologia password

### Testing Instructions
Imposta il parametro  Imponi cronologia password ad un valore maggiore di zero. Cambia la password più volte. Infine cambia la password utilizzando una delle ultime.

### Expected result
Impossibile cambiare la password
![passwordpolicy0016](https://user-images.githubusercontent.com/12718836/35636053-4a973caa-06b0-11e8-8b3a-58967b4a41cb.png)

### Documentation Changes Required
L'impostazione Imponi cronologia delle password definisce il numero di nuove password uniche che devono essere associate a un account utente prima che una vecchia password possa essere riutilizzata.
![passwordpolicy0019](https://user-images.githubusercontent.com/12718836/35635818-9cb3f466-06af-11e8-915a-89fd7589298f.png)
